### PR TITLE
1 add remove sets

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -1,0 +1,13 @@
+# Start Backend
+```bash
+cd backend
+uv run testusers.py
+uv run uvicorn main:app --reload
+```
+
+# Start Frontend
+```bash
+cd frontend
+npm install
+npm run dev -- --port 3000 --host
+```

--- a/frontend/src/components/ExerciseCard.tsx
+++ b/frontend/src/components/ExerciseCard.tsx
@@ -13,6 +13,18 @@ export default function ExerciseCard({ exercise, onExerciseChange }: ExerciseCar
     onExerciseChange({ ...exercise, sets: newSets });
   };
 
+  const handleRemoveSet = (index: number) => {
+    const newSets = exercise.sets.filter((_, i) => i !== index);
+    onExerciseChange({ ...exercise, sets: newSets });
+  };
+
+  const handleAddSet = () => {
+    const newSets = [...exercise.sets, { lbs: null, reps: null }];
+    onExerciseChange({ ...exercise, sets: newSets });
+  };
+
+  const isSingleSet = exercise.sets.length <= 1;
+
   return (
     <div className="flex rounded-2xl bg-white border border-neutral-200 overflow-hidden">
       <div className="flex flex-col items-center justify-between bg-neutral-100 px-2 py-3 min-w-[48px]">
@@ -33,8 +45,24 @@ export default function ExerciseCard({ exercise, onExerciseChange }: ExerciseCar
             setNumber={i + 1}
             value={set}
             onChange={(updated) => handleSetChange(i, updated)}
+            onRemove={() => handleRemoveSet(i)}
+            disableRemove={isSingleSet}
           />
         ))}
+        <div className="flex items-center gap-4 py-4">
+          <span className="w-8 text-lg text-neutral-400 shrink-0">
+            S{exercise.sets.length + 1}
+          </span>
+          <button
+            onClick={handleAddSet}
+            className="flex-1 rounded-md border border-dashed border-neutral-300 text-neutral-500
+                       py-1.5 text-sm font-medium
+                       hover:border-neutral-400 hover:text-neutral-700
+                       focus:outline-none focus:ring-2 focus:ring-neutral-400"
+          >
+            + Add Set
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/SetRow.tsx
+++ b/frontend/src/components/SetRow.tsx
@@ -4,9 +4,17 @@ type SetRowProps = {
   setNumber: number;
   value: WorkoutSet;
   onChange: (updated: WorkoutSet) => void;
+  onRemove?: () => void;
+  disableRemove?: boolean;
 };
 
-export default function SetRow({ setNumber, value, onChange }: SetRowProps) {
+export default function SetRow({
+  setNumber,
+  value,
+  onChange,
+  onRemove,
+  disableRemove = false,
+}: SetRowProps) {
   const handleLbsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value;
     onChange({ ...value, lbs: raw === "" ? null : Number(raw) });
@@ -41,10 +49,14 @@ export default function SetRow({ setNumber, value, onChange }: SetRowProps) {
         className="w-20 rounded-md border border-neutral-300 bg-white px-2 py-1.5 text-base text-center
                    placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-400"
       />
-      <button
-        aria-label={`Remove set ${setNumber}`}
+      {onRemove && (
+        <button
+          aria-label={`Remove set ${setNumber}`}
+          onClick={onRemove}
+          disabled={disableRemove}
         className="bg-neutral-200 text-neutral-500 hover:bg-red-400 focus:outline-none focus:ring-2 focus:ring-blue-400 active:ring-blue-600 w-8 rounded-md ml-4"
       > - </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/SetRow.tsx
+++ b/frontend/src/components/SetRow.tsx
@@ -41,6 +41,10 @@ export default function SetRow({ setNumber, value, onChange }: SetRowProps) {
         className="w-20 rounded-md border border-neutral-300 bg-white px-2 py-1.5 text-base text-center
                    placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-400"
       />
+      <button
+        aria-label={`Remove set ${setNumber}`}
+        className="bg-neutral-200 text-neutral-500 hover:bg-red-400 focus:outline-none focus:ring-2 focus:ring-blue-400 active:ring-blue-600 w-8 rounded-md ml-4"
+      > - </button>
     </div>
   );
 }

--- a/frontend/src/components/SetRow.tsx
+++ b/frontend/src/components/SetRow.tsx
@@ -54,8 +54,8 @@ export default function SetRow({
           aria-label={`Remove set ${setNumber}`}
           onClick={onRemove}
           disabled={disableRemove}
-        className="bg-neutral-200 text-neutral-500 hover:bg-red-400 focus:outline-none focus:ring-2 focus:ring-blue-400 active:ring-blue-600 w-8 rounded-md ml-4"
-      > - </button>
+        className="disabled:hover:bg-neutral-200 disabled:hover:text-neutral-500 disabled:opacity-30 disabled:cursor-not-allowed bg-neutral-200 text-neutral-500 hover:bg-red-400 focus:outline-none focus:ring-2 focus:ring-blue-400 active:ring-blue-600 w-8 rounded-md ml-auto"
+      > &minus; </button>
       )}
     </div>
   );


### PR DESCRIPTION
Add/remove sets during active workout
Adds dynamic set management to the workout screen — users can remove sets (disabled when only 1 remains) and add empty sets via an "Add Set" button.

Closes #1